### PR TITLE
Hotfix migration alter_cpf_column

### DIFF
--- a/database/migrations/2019_11_19_123956_alter_cpf_column.php
+++ b/database/migrations/2019_11_19_123956_alter_cpf_column.php
@@ -3,6 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Database;
 
 class AlterCpfColumn extends Migration
 {
@@ -13,6 +14,7 @@ class AlterCpfColumn extends Migration
      */
     public function up()
     {
+        DB::connection()->getDoctrineSchemaManager()->getDatabasePlatform()->registerDoctrineTypeMapping('enum', 'string');
         Schema::table('pacientes', function (Blueprint $table) {
             $table->string('cpf', 11)->nullable()->change();
         });
@@ -25,8 +27,9 @@ class AlterCpfColumn extends Migration
      */
     public function down()
     {
+        DB::connection()->getDoctrineSchemaManager()->getDatabasePlatform()->registerDoctrineTypeMapping('enum', 'string');
         Schema::table('pacientes', function (Blueprint $table) {
-            $table->string('cpf', 11)->change();;
+            $table->string('cpf', 11)->change();
         });
     }
 }


### PR DESCRIPTION
Consertei o problema que fazia com que a migration de cpf não rodasse. O erro ocorreu devido ao Doctrine não estar configurado para reconhecer tipos customizados. ( https://github.com/doctrine/dbal/issues/3161 )

Acredito que essa não é a forma ideal de resolver o problema, o mais correto talvez fosse definir o nosso tipo customizado, conforme: https://www.doctrine-project.org/projects/doctrine-orm/en/2.6/cookbook/mysql-enums.html#solution-2-defining-a-type